### PR TITLE
Allow non-https NS hostnames; stop supporting "NS" env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,8 +306,12 @@ if (!module.parent) {
   };
   var ns_config = {
     API_SECRET: readENV('API_SECRET')
-  , endpoint: readENV('NS', 'https://' + readENV('WEBSITE_HOSTNAME'))
+  , endpoint: readENV('WEBSITE_HOSTNAME')
   };
+  // Assume Nightscout hostname is reachable by https unless specified otherwise
+  if (ns_config.endpoint.indexOf('http://') !== 0 && ns_config.endpoint.indexOf('https://') !== 0) {
+    ns_config.endpoint = 'https://' + ns_config.endpoint;
+  }
   var interval = readENV('SHARE_INTERVAL', 60000 * 2.5);
   var fetch_config = { maxCount: readENV('maxCount', 1)
     , minutes: readENV('minutes', 1440)


### PR DESCRIPTION
My Nightscout setup is http-only, but share2nightscout-bridge prepends "https://" to `WEBSITE_HOSTNAME`. I discovered that I could set `NS` in my environment, but this isn't documented in any of the setup instructions in the wiki, so I think the best approach is to stop supporting an undocumented config variable, and instead allow `WEBSITE_HOSTNAME` to optionally specify a protocol.