### PR TITLE
Don't crash when server is down

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function engine (opts) {
       }
       fetch_opts.sessionID = my.sessionID;
       fetch(fetch_opts, function (err, res, glucose) {
-        if (res.statusCode < 400) {
+        if (!err && res.statusCode < 400) {
           to_nightscout(glucose);
         } else {
           my.sessionID = null;
@@ -235,7 +235,7 @@ function engine (opts) {
         my( );
       } else {
         failures++;
-        console.log("Error refreshing token", err, res.statusCode, body);
+        console.log("Error refreshing token", err, res && res.statusCode, body);
         if (failures >= opts.maxFailures) {
           throw "Too many login failures, check DEXCOM_ACCOUNT_NAME and DEXCOM_PASSWORD";
         }


### PR DESCRIPTION
Response is undefined when the connection cannot be established, which
caused res.statusCode to blow up with:
```
/usr/src/app/node_modules/share2nightscout-bridge/index.js:238
        console.log("Error refreshing token", err, res.statusCode, body);
                                                      ^

TypeError: Cannot read property 'statusCode' of undefined
```